### PR TITLE
refactor(core): add helper to get Assembly Informational version

### DIFF
--- a/src/SuperMassive/Helpers/AssemblyHelper.cs
+++ b/src/SuperMassive/Helpers/AssemblyHelper.cs
@@ -1,6 +1,5 @@
 ﻿namespace SuperMassive
 {
-    using System.Diagnostics;
     using System.Reflection;
 
     /// <summary>
@@ -9,23 +8,45 @@
     public static class AssemblyHelper
     {
         /// <summary>
+        /// Returns the file version of the executing assembly
+        /// </summary>
+        /// <returns>The file version of the executing assembly</returns>
+        public static string? GetFileVersion()
+        {
+            return GetFileVersion(typeof(AssemblyHelper).Assembly);
+        }
+
+        /// <summary>
+        /// Returns the file version of a given assembly
+        /// </summary>
+        /// <param name="assembly">Assembly used to get the file version</param>
+        /// <returns>The file version of the assembly</returns>
+        public static string? GetFileVersion(Assembly assembly)
+        {
+            return assembly
+                .GetCustomAttribute<AssemblyFileVersionAttribute>()?
+                .Version;
+        }
+
+        /// <summary>
         /// Returns the informational version of the executing assembly.
         /// </summary>
-        /// <returns></returns>
-        public static string GetInformationalVersion()
+        /// <returns>The informational version of the assembly</returns>
+        public static string? GetInformationalVersion()
         {
-            return FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
+            return GetInformationalVersion(typeof(AssemblyHelper).Assembly);
         }
 
         /// <summary>
         /// Returns the informational version of the given assembly.
         /// </summary>
-        /// <param name="assembly"></param>
-        /// <returns></returns>
-        // TODO: Fix Informational Version. Should comes from Assembly attributes
-        public static string GetInformationalVersion(Assembly assembly)
+        /// <param name="assembly">Assembly used to get the informational version</param>
+        /// <returns>The informational version of the assembly</returns>
+        public static string? GetInformationalVersion(Assembly assembly)
         {
-            return FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion;
+            return assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion;
         }
     }
 }

--- a/tests/SuperMassive.Tests.Unit/Helpers/AssemblyHelperTest.cs
+++ b/tests/SuperMassive.Tests.Unit/Helpers/AssemblyHelperTest.cs
@@ -1,0 +1,30 @@
+namespace SuperMassive.Tests.Unit.Helpers
+{
+    using System;
+    using NUnit.Framework;
+
+    public class AssemblyHelperTest
+    {
+        [TestCase(null)]
+        [TestCase(typeof(AssemblyHelper))]
+        public void GetFileVersion_Returns_NotNullOrEmpty_String(Type type)
+        {
+            var actual = type != null ?
+                AssemblyHelper.GetFileVersion(type.Assembly) :
+                AssemblyHelper.GetFileVersion();
+
+            Assert.That(actual, Is.Not.Empty);
+        }
+
+        [TestCase(null)]
+        [TestCase(typeof(AssemblyHelper))]
+        public void GetInformationalVersion(Type type)
+        {
+            var actual = type != null ?
+                AssemblyHelper.GetInformationalVersion(type.Assembly) :
+                AssemblyHelper.GetInformationalVersion();
+
+            Assert.That(actual, Is.Not.Empty);
+        }
+    }
+}


### PR DESCRIPTION
# Summary

This PR introduces a new utility fonction on the Assembly Helper to retrieve the File Version of a given Assembly.

# Changes description

* Add GetFileVersion method on AssemblyHelper
* Fix AssemblyHelper's GetInformationalVersion utility function

BREAKING CHANGES:
GetFileVersion and GetInformationalVersion of the AssemblyHelper class
now return a nullable string reference type.
This was the case in v1 of the SuperMassive library but this behavior has been
changed during the v2 .NET Core Migration.
This PR restore this initial behavior.