### PR TITLE
feat(core): improve CryptographyHelper API

### DIFF
--- a/src/SuperMassive/Helpers/CryptographyHelper.cs
+++ b/src/SuperMassive/Helpers/CryptographyHelper.cs
@@ -12,131 +12,318 @@
     public static class CryptographyHelper
     {
         /// <summary>
-        /// Compute the MD5 hash of a UTF-8 string
+        /// Compute the MD5 hash of a UTF-8 string and returns its hexadecimal string representation
         /// </summary>
-        /// <param name="value"></param>
-        /// <returns>The md5 hashed string</returns>
-        public static string ComputeMD5Hash(string value)
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the MD5 hash or null if the provided value is null</returns>
+        [Obsolete("Deprecated. Use GetMd5Hash() instead")]
+        public static string? ComputeMD5Hash(string value)
+            => GetMd5Hash(value);
+
+        /// <summary>
+        /// Compute the MD5 hash of a UTF-8 string and returns its hexadecimal string representation
+        /// </summary>
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the MD5 hash or null if the provided value is null</returns>
+        public static string? GetMd5Hash(string value)
         {
-            if (value == string.Empty)
-                return string.Empty;
+            if (value == null)
+            {
+                return null;
+            }
 
             using var hasher = MD5.Create();
             return ByteToHex(hasher.ComputeHash(Encoding.UTF8.GetBytes(value)));
         }
 
         /// <summary>
-        /// Computes the MD5 hash from a file content.
+        /// Compute the MD5 hash of a UTF-8 string and returns its hexadecimal string representation
         /// </summary>
-        /// <param name="fileName"></param>
-        /// <param name="base64"></param>
-        /// <returns></returns>
-        public static string ComputeMD5HashFromFile(string fileName, bool base64 = false)
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the MD5 hash or null if the provided value is null</returns>
+        public static string? ToMd5Hash(this string value)
+            => GetMd5Hash(value);
+
+        /// <summary>
+        /// Computes the MD5 hash of a file content and returns its hexadecimal string representation
+        /// </summary>
+        /// <param name="filePath">Path to the file</param>
+        /// <param name="base64">True if the hexadecimal representation should be encoded into base64 prior to be returned</param>
+        /// <returns>The hexadecimal representation of the MD5 hash or null if the file does not exist</returns>
+        [Obsolete("Deprecated. Use GetMd5HashFromFile() instead")]
+        public static string? ComputeMD5HashFromFile(string filePath, bool base64 = false)
+            => GetMd5HashFromFile(filePath, base64);
+
+        /// <summary>
+        /// Computes the MD5 hash of a file content and returns its hexadecimal string representation
+        /// </summary>
+        /// <param name="filePath">Path to the file</param>
+        /// <param name="base64">True if the hexadecimal representation should be encoded into base64 prior to be returned</param>
+        /// <returns>The hexadecimal representation of the MD5 hash or null if the file does not exist</returns>
+        public static string? GetMd5HashFromFile(string filePath, bool base64 = false)
         {
-            using var stream = File.OpenRead(fileName);
+            if (!File.Exists(filePath))
+            {
+                return null;
+            }
+
+            using var stream = File.OpenRead(filePath);
             using var hasher = MD5.Create();
             return ComputeHashFromStream(stream, hasher, base64);
         }
 
         /// <summary>
-        /// Compute the SHA256 hash of a UTF-8 string
+        /// Compute the SHA-1 hash of a UTF-8 string and returns its hexadecimal string representation
         /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public static string ComputeSHA256Hash(string value)
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the SHA-1 hash or null if the provided value is null</returns>
+        [Obsolete("Deprecated. Use GetSha1Hash() instead")]
+        public static string? ComputeSHA1Hash(string value)
+            => GetSha1Hash(value);
+
+        /// <summary>
+        /// Compute the SHA-1 hash of a UTF-8 string and returns its hexadecimal string representation
+        /// </summary>
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the SHA-1 hash or null if the provided value is null</returns>
+        public static string? GetSha1Hash(string value)
         {
-            if (value == string.Empty)
-                return string.Empty;
+            if (value == null)
+            {
+                return null;
+            }
+
+            using var hasher = SHA1.Create();
+            return ByteToHex(hasher.ComputeHash(Encoding.UTF8.GetBytes(value)));
+        }
+
+        /// <summary>
+        /// Compute the SHA-1 hash of a UTF-8 string and returns its hexadecimal string representation
+        /// </summary>
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the SHA-1 hash or null if the provided value is null</returns>
+        public static string? ToSha1Hash(this string value)
+            => GetSha1Hash(value);
+
+        /// <summary>
+        /// Computes the SHA-1 hash of a file content and returns its hexadecimal string representation
+        /// </summary>
+        /// <param name="filePath">Path to the file</param>
+        /// <param name="base64">True if the hexadecimal representation should be encoded into base64 prior to be returned</param>
+        /// <returns>The hexadecimal representation of the SHA-1 hash or null if the file does not exist</returns>
+        [Obsolete("Deprecated. Use GetSha1HashFromFile() instead")]
+        public static string? ComputeSHA1HashFromFile(string filePath, bool base64 = false)
+            => GetSha1HashFromFile(filePath, base64);
+
+        /// <summary>
+        /// Computes the SHA-1 hash of a file content and returns its hexadecimal string representation
+        /// </summary>
+        /// <param name="filePath">Path to the file</param>
+        /// <param name="base64">True if the hexadecimal representation should be encoded into base64 prior to be returned</param>
+        /// <returns>The hexadecimal representation of the SHA-1 hash or null if the file does not exist</returns>
+        public static string? GetSha1HashFromFile(string filePath, bool base64 = false)
+        {
+            if (!File.Exists(filePath))
+            {
+                return null;
+            }
+
+            using var stream = File.OpenRead(filePath);
+            using var hasher = SHA1.Create();
+            return ComputeHashFromStream(stream, hasher, base64);
+        }
+
+        /// <summary>
+        /// Compute the SHA-256 hash of a UTF-8 string and returns its hexadecimal string representation
+        /// </summary>
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the SHA-256 hash or null if the provided value is null</returns>
+        [Obsolete("Deprecated. Use GetSha256Hash() instead")]
+        public static string? ComputeSHA256Hash(string value)
+            => GetSha256Hash(value);
+
+        /// <summary>
+        /// Compute the SHA-256 hash of a UTF-8 string and returns its hexadecimal string representation
+        /// </summary>
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the SHA-256 hash or null if the provided value is null</returns>
+        public static string? GetSha256Hash(string value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
 
             using var hasher = SHA256.Create();
             return ByteToHex(hasher.ComputeHash(Encoding.UTF8.GetBytes(value)));
         }
 
         /// <summary>
-        /// Computes the SHA256 hash from a file content.
+        /// Compute the SHA-256 hash of a UTF-8 string and returns its hexadecimal string representation
         /// </summary>
-        /// <param name="fileName"></param>
-        /// <param name="base64"></param>
-        /// <returns></returns>
-        public static string ComputeSHA256HashFromFile(string fileName, bool base64 = false)
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the SHA-256 hash or null if the provided value is null</returns>
+        public static string? ToSha256Hash(this string value)
+            => GetSha256Hash(value);
+
+        /// <summary>
+        /// Computes the SHA-256 hash of a file content and returns its hexadecimal string representation
+        /// </summary>
+        /// <param name="filePath">Path to the file</param>
+        /// <param name="base64">True if the hexadecimal representation should be encoded into base64 prior to be returned</param>
+        /// <returns>The hexadecimal representation of the SHA-256 hash or null if the file does not exist</returns>
+        [Obsolete("Deprecated. Use GetSha256HashFromFile() instead")]
+        public static string? ComputeSHA256HashFromFile(string filePath, bool base64 = false)
+            => GetSha256HashFromFile(filePath, base64);
+
+        /// <summary>
+        /// Computes the SHA-256 hash of a file content and returns its hexadecimal string representation
+        /// </summary>
+        /// <param name="filePath">Path to the file</param>
+        /// <param name="base64">True if the hexadecimal representation should be encoded into base64 prior to be returned</param>
+        /// <returns>The hexadecimal representation of the SHA-256 hash or null if the file does not exist</returns>
+        public static string? GetSha256HashFromFile(string filePath, bool base64 = false)
         {
-            using var stream = File.OpenRead(fileName);
+            if (!File.Exists(filePath))
+            {
+                return null;
+            }
+
+            using var stream = File.OpenRead(filePath);
             using var hasher = SHA256.Create();
             return ComputeHashFromStream(stream, hasher, base64);
         }
 
-        /// <summary>
-        /// Compute the SHA1 hash of a UTF-8 string
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public static string ComputeSHA1Hash(string value)
-        {
-            if (value == string.Empty)
-                return string.Empty;
-            using var hasher = SHA1.Create();
-            return ByteToHex(hasher.ComputeHash(Encoding.UTF8.GetBytes(value)));
-        }
 
         /// <summary>
-        /// Computes the SHA1 hash from a file content.
+        /// Compute the CRC-32 hash of a UTF-8 string and returns its hexadecimal string representation
         /// </summary>
-        /// <param name="fileName"></param>
-        /// <param name="base64"></param>
-        /// <returns></returns>
-        public static string ComputeSHA1HashFromFile(string fileName, bool base64 = false)
-        {
-            using var stream = File.OpenRead(fileName);
-            using var hasher = SHA1.Create();
-            return ComputeHashFromStream(stream, hasher, base64);
-        }
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the CRC-32 hash or null if the provided value is null</returns>
+        [Obsolete("Deprecated. Use GetCrc32Hash() instead")]
+        public static string? ComputeCRC32Hash(string value)
+            => GetCrc32Hash(value);
 
         /// <summary>
-        /// This method computes the CRC32 hash of the given value
+        /// Compute the CRC-32 hash of a UTF-8 string and returns its hexadecimal string representation
         /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public static string ComputeCRC32Hash(string value)
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the CRC-32 hash or null if the provided value is null</returns>
+        public static string? GetCrc32Hash(string value)
         {
-            if (value == string.Empty)
-                return string.Empty;
+            if (value == null)
+            {
+                return null;
+            }
 
             using var crc32 = new Crc32();
             return ByteToHex(crc32.ComputeHash(Encoding.UTF8.GetBytes(value)));
         }
 
         /// <summary>
-        /// This method computes the CRC32 hash of the given value
+        /// Compute the CRC-32 hash of a UTF-8 string and returns its hexadecimal string representation
         /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public static byte[] ComputeCRC32HashByte(string value)
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the CRC-32 hash or null if the provided value is null</returns>
+        public static string? ToCrc32Hash(this string value)
+            => GetCrc32Hash(value);
+
+        /// <summary>
+        /// Computes the CRC-32 hash of a file content and returns its hexadecimal string representation
+        /// </summary>
+        /// <param name="filePath">Path to the file</param>
+        /// <param name="base64">True if the hexadecimal representation should be encoded into base64 prior to be returned</param>
+        /// <returns>The hexadecimal representation of the CRC-32 hash or null if the file does not exist</returns>
+        public static string? GetCrc32HashFromFile(string filePath, bool base64 = false)
         {
-            var crc32 = new Crc32();
+            if (!File.Exists(filePath))
+            {
+                return null;
+            }
+
+            using var stream = File.OpenRead(filePath);
+            using var hasher = new Crc32();
+            return ComputeHashFromStream(stream, hasher, base64);
+        }
+
+        /// <summary>
+        /// Compute the CRC-32 hash of a UTF-8 string
+        /// </summary>
+        /// <param name="value">Value to hash</param>
+        /// <returns>An array of bytes or null if the provided value is null</returns>
+        public static byte[]? ComputeCRC32HashByte(string value)
+            => GetCrc32HashBytes(value);
+
+        /// <summary>
+        /// Compute the CRC-32 hash of a UTF-8 string
+        /// </summary>
+        /// <param name="value">Value to hash</param>
+        /// <returns>An array of bytes or null if the provided value is null</returns>
+        public static byte[]? GetCrc32HashBytes(string value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            using var crc32 = new Crc32();
             return crc32.ComputeHash(Encoding.UTF8.GetBytes(value));
         }
 
         /// <summary>
-        /// This method compute the CRC16 hash of the given value.
+        /// Compute the CRC-16 hash of a UTF-8 string and returns its hexadecimal string representation
         /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public static string ComputeCRC16Hash(string value)
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the CRC-16 hash or null if the provided value is null</returns>
+        [Obsolete("Deprecated. Use GetCrc16() instead")]
+        public static string? ComputeCRC16Hash(string value)
+            => GetCrc16Hash(value);
+
+        /// <summary>
+        /// Compute the CRC-16 hash of a UTF-8 string and returns its hexadecimal string representation
+        /// </summary>
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the CRC-16 hash or null if the provided value is null</returns>
+        public static string? GetCrc16Hash(string value)
         {
-            Guard.ArgumentNotNullOrWhiteSpace(value, nameof(value));
+            if (value == null)
+            {
+                return null;
+            }
 
             var crc16 = new Crc16Ccitt();
             return ByteToHex(crc16.ComputeHashBytes(Encoding.UTF8.GetBytes(value)));
         }
 
         /// <summary>
-        /// This method computes the CRC16 hash of the given value
+        /// Compute the CRC-16 hash of a UTF-8 string and returns its hexadecimal string representation
         /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        // TODO: Rename ComputeCRC16HashByte to ComputeCrc16HashBits and deprecated previous name
-        public static byte[] ComputeCRC16HashByte(string value)
+        /// <param name="value">Value to hash</param>
+        /// <returns>The hexadecimal representation of the CRC-16 hash or null if the provided value is null</returns>
+        public static string? ToCrc16Hash(this string value)
+            => GetCrc16Hash(value);
+
+        /// <summary>
+        /// Compute the CRC-16 hash of a UTF-8 string
+        /// </summary>
+        /// <param name="value">Value to hash</param>
+        /// <returns>An array of bytes or null if the provided value is null</returns>
+        [Obsolete("Deprecated. Use GetCrc16HashBytes() instead")]
+        public static byte[]? ComputeCRC16HashByte(string value)
+            => GetCrc16HashBytes(value);
+
+        /// <summary>
+        /// Compute the CRC-16 hash of a UTF-8 string
+        /// </summary>
+        /// <param name="value">Value to hash</param>
+        /// <returns>An array of bytes or null if the provided value is null</returns>
+        public static byte[]? GetCrc16HashBytes(string value)
         {
+            if (value == null)
+            {
+                return null;
+            }
+
             var crc16 = new Crc16Ccitt();
             return crc16.ComputeHashBytes(Encoding.UTF8.GetBytes(value));
         }
@@ -144,15 +331,17 @@
         /// <summary>
         /// Returns the Hexadecimal representation of the byte array
         /// </summary>
-        /// <param name="bits"></param>
-        /// <returns></returns>
-        public static string ByteToHex(byte[] bits)
+        /// <param name="value"></param>
+        /// <returns>The hexadecimal string representation or null if the provided value is null</returns>
+        public static string? ByteToHex(byte[] value)
         {
-            if (bits == null)
-                return string.Empty;
+            if (value == null)
+            {
+                return null;
+            }
 
-            var hex = new StringBuilder(bits.Length * 2);
-            foreach (var item in bits)
+            var hex = new StringBuilder(value.Length * 2);
+            foreach (var item in value)
             {
                 hex.Append(item.ToString("x2"));
             }
@@ -161,32 +350,36 @@
         }
 
         /// <summary>
-        /// This method encodes an UTF-8 string into a Base64 string
+        /// Returns the Hexadecimal representation of the byte array
         /// </summary>
         /// <param name="value"></param>
-        /// <returns></returns>
-        public static string EncodeToBase64(string value)
+        /// <returns>The hexadecimal string representation or null if the provided value is null</returns>
+        public static string? ToHex(this byte[] value)
+            => ByteToHex(value);
+
+        /// <summary>
+        /// Encodes a string into its base64 representation
+        /// </summary>
+        /// <param name="value">The value to encode</param>
+        /// <returns>The base64 representation or null if the provided value is null</returns>
+        public static string? EncodeToBase64(string value)
         {
-            var bytes = Encoding.UTF8.GetBytes(value);
-            return Convert.ToBase64String(bytes);
+            return value == null ? null : Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
         }
 
         /// <summary>
-        /// This method decodes a Base64 string into an UTF-8 string
+        /// Decodes a base64 string
         /// </summary>
-        /// <param name="encodedValue"></param>
-        /// <returns></returns>
-        public static string DecodeBase64(string encodedValue)
+        /// <param name="value">The value to decode</param>
+        /// <returns>The decoded string or null if the provided value is null</returns>
+        public static string? DecodeBase64(string value)
         {
-            var bytes = Convert.FromBase64String(encodedValue);
-            return Encoding.UTF8.GetString(bytes);
+            return value == null ? null : Encoding.UTF8.GetString(Convert.FromBase64String(value));
         }
 
-        internal static string ComputeHashFromStream(Stream stream, HashAlgorithm hasher, bool base64)
+        // Internal for testing purposes
+        internal static string? ComputeHashFromStream(Stream stream, HashAlgorithm hasher, bool base64)
         {
-            if (stream.Length == 0)
-                return string.Empty;
-
             return base64
                 ? Convert.ToBase64String(hasher.ComputeHash(stream))
                 : ByteToHex(hasher.ComputeHash(stream));

--- a/tests/SuperMassive.Tests.Unit/Helpers/CryptographyHelperTest.cs
+++ b/tests/SuperMassive.Tests.Unit/Helpers/CryptographyHelperTest.cs
@@ -1,5 +1,6 @@
 ﻿namespace SuperMassive.Tests.Unit.Helpers
 {
+    using System;
     using System.IO;
     using System.Security.Cryptography;
     using System.Text;
@@ -7,148 +8,253 @@
 
     public class CryptographyHelperTest
     {
-        [TestCase("", "")]
-        [TestCase(" ", "7215ee9c7d9dc229d2921a40e899ec5f")]
-        [TestCase("SuperMassive", "cad0d67d052f61ad42b0010983663a45")]
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Md5))]
         public void ComputeMD5Hash_Returns_Expected_Hash(string value, string expected)
         {
-            Assert.That(expected, Is.EqualTo(CryptographyHelper.ComputeMD5Hash(value)));
+#pragma warning disable 618
+            Assert.That(CryptographyHelper.ComputeMD5Hash(value), Is.EqualTo(expected));
+#pragma warning restore 618
         }
 
-        [TestCase("SuperMassive", "cad0d67d052f61ad42b0010983663a45")]
-        [TestCase("SuperMassive", "ytDWfQUvYa1CsAEJg2Y6RQ==", true)]
-        public void ComputeMD5HashFromFile_Returns_Expected_Hash(string value, string expected, bool base64 = false)
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Md5))]
+        public void GetMd5Hash_Returns_Expected_Hash(string value, string expected)
         {
-            var fileName = CreateTemporaryFile(value);
-
-            Assert.That(
-                CryptographyHelper.ComputeMD5HashFromFile(fileName, base64),
-                Is.EqualTo(expected));
-
-            if(File.Exists(fileName))
-                File.Delete(fileName);
+            Assert.That(CryptographyHelper.GetMd5Hash(value), Is.EqualTo(expected));
         }
 
-        [TestCase("", "")]
-        [TestCase(" ", "36a9e7f1c95b82ffb99743e0c5c4ce95d83c9a430aac59f84ef3cbfab6145068")]
-        [TestCase("SuperMassive", "9296c1a118328aad1201f1dcfead4d5aeb84580fae41157afacc4367f3e8b3d9")]
-        public void ComputeSHA256Hash_Returns_Expected_Hash(string value, string expected)
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Md5))]
+        public void ToMd5Hash_Returns_Expected_Hash(string value, string expected)
         {
-            Assert.That(CryptographyHelper.ComputeSHA256Hash(value), Is.EqualTo(expected));
+            Assert.That(value.ToMd5Hash(), Is.EqualTo(expected));
         }
 
-        [TestCase("SuperMassive", "9296c1a118328aad1201f1dcfead4d5aeb84580fae41157afacc4367f3e8b3d9")]
-        [TestCase("SuperMassive", "kpbBoRgyiq0SAfHc/q1NWuuEWA+uQRV6+sxDZ/Pos9k=", true)]
-        public void ComputeSHA256HashFromFile_Returns_Expected_Hash(string value, string expected, bool base64 = false)
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Md5File))]
+        public void ComputeMD5HashFromFile_Returns_Expected_Hash(string value, string expected, bool base64)
         {
-            var fileName = CreateTemporaryFile(value);
-
-            Assert.That(
-                expected,
-                Is.EqualTo(
-                    CryptographyHelper.ComputeSHA256HashFromFile(fileName, base64)));
-
-            if (File.Exists(fileName))
-                File.Delete(fileName);
+#pragma warning disable 618
+            AssertHashFromFile(value, expected, base64, CryptographyHelper.ComputeMD5HashFromFile);
+#pragma warning restore 618
         }
 
-        [TestCase("", "")]
-        [TestCase(" ", "b858cb282617fb0956d960215c8e84d1ccf909c6")]
-        [TestCase("SuperMassive", "ba3fff6f7041385c8b75901f421e5c2db081ebea")]
-        public void ComputeSHA1Hash_Returns_Expected_Hash(string value, string expected)
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Md5File))]
+        public void GetMd5HashFromFile_Returns_Expected_Hash(string value, string expected, bool base64)
         {
-            Assert.That(CryptographyHelper.ComputeSHA1Hash(value), Is.EqualTo(expected));
-        }
-
-        [TestCase("SuperMassive", "ba3fff6f7041385c8b75901f421e5c2db081ebea")]
-        [TestCase("SuperMassive", "uj//b3BBOFyLdZAfQh5cLbCB6+o=", true)]
-        public void ComputeSHA1HashFromFile_Returns_Expected_Hash(string value, string expected, bool base64 = false)
-        {
-            var fileName = CreateTemporaryFile(value);
-
-            Assert.That(
-                CryptographyHelper.ComputeSHA1HashFromFile(fileName, base64),
-                Is.EqualTo(expected));
-
-            if (File.Exists(fileName))
-                File.Delete(fileName);
-        }
-
-        [TestCase("", "")]
-        [TestCase(" ", "e96ccf45")]
-        [TestCase("SuperMassive", "93ba819f")]
-        public void ComputeCRC32Hash_Returns_Expected_Hash(string value, string expected)
-        {
-            Assert.That(CryptographyHelper.ComputeCRC32Hash(value), Is.EqualTo(expected));
-        }
-
-        [Test]
-        public void ComputeCRC32HashByte_Returns_Expected_Hash()
-        {
-            const string input = "2520056747225332399_63a5c229-2461-4e7c-805d-82394a99bd11";
-            const string expected = "eff6144a";
-
-            Assert.That(
-                CryptographyHelper.ByteToHex(
-                    CryptographyHelper.ComputeCRC32HashByte(input)),
-                Is.EqualTo(expected));
-        }
-
-        [Test]
-        public void ComputeCRC16Hash_Returns_Expected_Hash()
-        {
-            const string input = "2520056747225332399_63a5c229-2461-4e7c-805d-82394a99bd11";
-            const string expected = "97a1";
-
-            Assert.That(CryptographyHelper.ComputeCRC16Hash(input), Is.EqualTo(expected));
-        }
-
-        [Test]
-        public void ComputeCRC16HashByte_Returns_Expected_Bits()
-        {
-            const string input = "2520056747225332399_63a5c229-2461-4e7c-805d-82394a99bd11";
-            const string expected = "97a1";
-
-            Assert.That(
-                CryptographyHelper.ByteToHex(
-                    CryptographyHelper.ComputeCRC16HashByte(input)),
-                Is.EqualTo(expected));
-        }
-
-        [TestCase("", "")]
-        [TestCase(" ", "20")]
-        [TestCase("SuperMassive", "53757065724d617373697665")]
-        public void ByteToHex_Returns_Expected_Hexadecimal_Value(string value, string expected)
-        {
-            Assert.That(
-                CryptographyHelper.ByteToHex(Encoding.UTF8.GetBytes(value)),
-                Is.EqualTo(expected));
+            AssertHashFromFile(value, expected, base64, CryptographyHelper.GetMd5HashFromFile);
         }
 
         [TestCase(null)]
-        [TestCase(new byte[0])]
-        public void ByteToHex_Returns_EmptyString_When_ByteArray_Is_Null_Or_Empty(byte[] value)
+        [TestCase("")]
+        [TestCase("unknown")]
+        public void GetMd5HashFromFile_Returns_Null_When_File_Does_Not_Exist(string filePath)
         {
-            Assert.That(CryptographyHelper.ByteToHex(value), Is.Empty);
+            Assert.That(CryptographyHelper.GetMd5HashFromFile(filePath), Is.Null);
         }
 
-        [TestCase("", "")]
-        [TestCase(" ", "IA==")]
-        [TestCase("SuperMassive", "U3VwZXJNYXNzaXZl")]
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Sha1))]
+        public void ComputeSHA1Hash_Returns_Expected_Hash(string value, string expected)
+        {
+#pragma warning disable 618
+            Assert.That(CryptographyHelper.ComputeSHA1Hash(value), Is.EqualTo(expected));
+#pragma warning restore 618
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Sha1))]
+        public void GetSha1Hash_Returns_Expected_Hash(string value, string expected)
+        {
+            Assert.That(CryptographyHelper.GetSha1Hash(value), Is.EqualTo(expected));
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Sha1))]
+        public void ToSha1Hash_Returns_Expected_Hash(string value, string expected)
+        {
+            Assert.That(value.ToSha1Hash(), Is.EqualTo(expected));
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Sha1File))]
+        public void ComputeSHA1HashFromFile_Returns_Expected_Hash(string value, string expected, bool base64 = false)
+        {
+#pragma warning disable 618
+            AssertHashFromFile(value, expected, base64, CryptographyHelper.ComputeSHA1HashFromFile);
+#pragma warning restore 618
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Sha1File))]
+        public void GetSha1HashFromFile_Returns_Expected_Hash(string value, string expected, bool base64 = false)
+        {
+            AssertHashFromFile(value, expected, base64, CryptographyHelper.GetSha1HashFromFile);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("unknown")]
+        public void GetSha1HashFromFile_Returns_Null_When_File_Does_Not_Exist(string filePath)
+        {
+            Assert.That(CryptographyHelper.GetSha1HashFromFile(filePath), Is.Null);
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Sha256))]
+        public void ComputeSHA256Hash_Returns_Expected_Hash(string value, string expected)
+        {
+#pragma warning disable 618
+            Assert.That(CryptographyHelper.ComputeSHA256Hash(value), Is.EqualTo(expected));
+#pragma warning restore 618
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Sha256))]
+        public void GetSha256Hash_Returns_Expected_Hash(string value, string expected)
+        {
+            Assert.That(CryptographyHelper.GetSha256Hash(value), Is.EqualTo(expected));
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Sha256))]
+        public void ToSha256Hash_Returns_Expected_Hash(string value, string expected)
+        {
+            Assert.That(value.ToSha256Hash(), Is.EqualTo(expected));
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Sha256File))]
+        public void ComputeSHA256HashFromFile_Returns_Expected_Hash(string value, string expected, bool base64 = false)
+        {
+#pragma warning disable 618
+            AssertHashFromFile(value, expected, base64, CryptographyHelper.ComputeSHA256HashFromFile);
+#pragma warning restore 618
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Sha256File))]
+        public void GetSha256HashFromFile_Returns_Expected_Hash(string value, string expected, bool base64 = false)
+        {
+            AssertHashFromFile(value, expected, base64, CryptographyHelper.GetSha256HashFromFile);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("unknown")]
+        public void GetSha256HashFromFile_Returns_Null_When_File_Does_Not_Exist(string filePath)
+        {
+            Assert.That(CryptographyHelper.GetSha256HashFromFile(filePath), Is.Null);
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Crc32))]
+        public void ComputeCRC32Hash_Returns_Expected_Hash(string value, string expected)
+        {
+#pragma warning disable 618
+            Assert.That(CryptographyHelper.ComputeCRC32Hash(value), Is.EqualTo(expected));
+#pragma warning restore 618
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Crc32))]
+        public void GetCrc32Hash_Returns_Expected_Hash(string value, string expected)
+        {
+            Assert.That(CryptographyHelper.GetCrc32Hash(value), Is.EqualTo(expected));
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Crc32))]
+        public void ToCrc32Hash_Returns_Expected_Hash(string value, string expected)
+        {
+            Assert.That(value.ToCrc32Hash(), Is.EqualTo(expected));
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Crc32File))]
+        public void GetCrc32HashFromFile_Returns_Expected_Hash(string value, string expected, bool base64 = false)
+        {
+            AssertHashFromFile(value, expected, base64, CryptographyHelper.GetCrc32HashFromFile);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("unknown")]
+        public void GetCrc32HashFromFile_Returns_Null_When_File_Does_Not_Exist(string filePath)
+        {
+            Assert.That(CryptographyHelper.GetCrc32HashFromFile(filePath), Is.Null);
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Crc32))]
+        public void ComputeCRC32HashByte_Returns_Expected_Hash(string value, string expected)
+        {
+            Assert.That(
+                CryptographyHelper.ByteToHex(
+                    CryptographyHelper.ComputeCRC32HashByte(value)),
+                Is.EqualTo(expected));
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Crc32))]
+        public void GetCrc32HashBytes_Returns_Expected_Hash(string value, string expected)
+        {
+            Assert.That(
+                CryptographyHelper.ByteToHex(
+                    CryptographyHelper.GetCrc32HashBytes(value)),
+                Is.EqualTo(expected));
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Crc16))]
+        public void ComputeCRC16Hash_Returns_Expected_Hash(string value, string expected)
+        {
+#pragma warning disable 618
+            Assert.That(CryptographyHelper.ComputeCRC16Hash(value), Is.EqualTo(expected));
+#pragma warning restore 618
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Crc16))]
+        public void GetCrc16Hash_Returns_Expected_Hash(string value, string expected)
+        {
+            Assert.That(CryptographyHelper.GetCrc16Hash(value), Is.EqualTo(expected));
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Crc16))]
+        public void ToCrc16Hash_Returns_Expected_Hash(string value, string expected)
+        {
+            Assert.That(value.ToCrc16Hash(), Is.EqualTo(expected));
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Crc16))]
+        public void ComputeCRC16HashByte_Returns_Expected_Hash(string value, string expected)
+        {
+            Assert.That(
+                CryptographyHelper.ByteToHex(
+#pragma warning disable 618
+                    CryptographyHelper.ComputeCRC16HashByte(value)),
+#pragma warning restore 618
+                Is.EqualTo(expected));
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Crc16))]
+        public void GetCrc16HashBytes_Returns_Expected_Hash(string value, string expected)
+        {
+            Assert.That(
+                CryptographyHelper.ByteToHex(
+                    CryptographyHelper.GetCrc16HashBytes(value)),
+                Is.EqualTo(expected));
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.ByteToHex))]
+        public void ByteToHex_Returns_Expected_Hexadecimal_Value(byte[] value, string expected)
+        {
+            Assert.That(
+                CryptographyHelper.ByteToHex(value),
+                Is.EqualTo(expected));
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.ByteToHex))]
+        public void ToHex_Returns_Expected_Hexadecimal_Value(byte[] value, string expected)
+        {
+            Assert.That(
+                value.ToHex(),
+                Is.EqualTo(expected));
+        }
+
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Base64))]
         public void EncodeToBase64Test(string value, string expected)
         {
             Assert.That(CryptographyHelper.EncodeToBase64(value), Is.EqualTo(expected));
         }
 
-        [TestCase("", "")]
-        [TestCase("IA==", " ")]
-        [TestCase("U3VwZXJNYXNzaXZl", "SuperMassive")]
-        public void DecodeBase64Test(string value, string expected)
+        [TestCaseSource(typeof(TestCases), nameof(TestCases.Base64))]
+        public void DecodeBase64Test(string expected, string value)
         {
             Assert.That(CryptographyHelper.DecodeBase64(value), Is.EqualTo(expected));
         }
 
-        [TestCase("", "")]
+        [TestCase("", "d41d8cd98f00b204e9800998ecf8427e")]
         [TestCase(" ", "7215ee9c7d9dc229d2921a40e899ec5f")]
         [TestCase("SuperMassive", "cad0d67d052f61ad42b0010983663a45")]
         [TestCase("SuperMassive", "ytDWfQUvYa1CsAEJg2Y6RQ==", true)]
@@ -167,6 +273,104 @@
             var fileName = Path.GetTempFileName();
             File.WriteAllText(fileName, content);
             return fileName;
+        }
+
+        private static void AssertHashFromFile(
+            string value,
+            string expected,
+            bool base64,
+            Func<string, bool, string> hashMethod)
+        {
+            var fileName = CreateTemporaryFile(value);
+            var actual = hashMethod(fileName, base64);
+            if (File.Exists(fileName))
+                File.Delete(fileName);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        private class TestCases
+        {
+            public static object[] Md5 =
+            {
+                new object[] { null, null },
+                new object[] { string.Empty, "d41d8cd98f00b204e9800998ecf8427e" },
+                new object[] { " ", "7215ee9c7d9dc229d2921a40e899ec5f" },
+                new object[] { "SuperMassive", "cad0d67d052f61ad42b0010983663a45" },
+            };
+
+            public static object[] Md5File =
+            {
+                new object[] { "SuperMassive", "cad0d67d052f61ad42b0010983663a45", false },
+                new object[] { "SuperMassive", "ytDWfQUvYa1CsAEJg2Y6RQ==", true },
+            };
+
+            public static object[] Sha1 =
+            {
+                new object[] { null, null },
+                new object[] { string.Empty, "da39a3ee5e6b4b0d3255bfef95601890afd80709" },
+                new object[] { " ", "b858cb282617fb0956d960215c8e84d1ccf909c6" },
+                new object[] { "SuperMassive", "ba3fff6f7041385c8b75901f421e5c2db081ebea" },
+            };
+
+            public static object[] Sha1File =
+            {
+                new object[] { "SuperMassive", "ba3fff6f7041385c8b75901f421e5c2db081ebea", false },
+                new object[] { "SuperMassive", "uj//b3BBOFyLdZAfQh5cLbCB6+o=", true },
+            };
+
+            public static object[] Sha256 =
+            {
+                new object[] { null, null },
+                new object[] { string.Empty, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" },
+                new object[] { " ", "36a9e7f1c95b82ffb99743e0c5c4ce95d83c9a430aac59f84ef3cbfab6145068" },
+                new object[] { "SuperMassive", "9296c1a118328aad1201f1dcfead4d5aeb84580fae41157afacc4367f3e8b3d9" },
+            };
+
+            public static object[] Sha256File =
+            {
+                new object[]
+                    { "SuperMassive", "9296c1a118328aad1201f1dcfead4d5aeb84580fae41157afacc4367f3e8b3d9", false },
+                new object[] { "SuperMassive", "kpbBoRgyiq0SAfHc/q1NWuuEWA+uQRV6+sxDZ/Pos9k=", true },
+            };
+
+            public static object[] Crc32 =
+            {
+                new object[] { null, null },
+                new object[] { string.Empty, "00000000" },
+                new object[] { " ", "e96ccf45" },
+                new object[] { "SuperMassive", "93ba819f" },
+            };
+
+            public static object[] Crc32File =
+            {
+                new object[] { "SuperMassive", "93ba819f", false },
+                new object[] { "SuperMassive", "k7qBnw==", true },
+            };
+
+            public static object[] Crc16 =
+            {
+                new object[] { null, null },
+                new object[] { string.Empty, "0000" },
+                new object[] { " ", "0221" },
+                new object[] { "SuperMassive", "184b" },
+            };
+
+            public static object[] ByteToHex =
+            {
+                new object[] { null, null },
+                new object[] { Encoding.UTF8.GetBytes(string.Empty), string.Empty },
+                new object[] { Encoding.UTF8.GetBytes(" "), "20" },
+                new object[] { Encoding.UTF8.GetBytes("SuperMassive"), "53757065724d617373697665" },
+            };
+
+            public static object[] Base64 =
+            {
+                new object[] { null, null },
+                new object[] { string.Empty, string.Empty },
+                new object[] { " ", "IA==" },
+                new object[] { "SuperMassive", "U3VwZXJNYXNzaXZl" },
+            };
         }
     }
 }

--- a/tests/SuperMassive.Tests.Unit/Helpers/CryptographyHelperTest.cs
+++ b/tests/SuperMassive.Tests.Unit/Helpers/CryptographyHelperTest.cs
@@ -289,9 +289,9 @@
             Assert.That(actual, Is.EqualTo(expected));
         }
 
-        private class TestCases
+        private static class TestCases
         {
-            public static object[] Md5 =
+            public static readonly object[] Md5 =
             {
                 new object[] { null, null },
                 new object[] { string.Empty, "d41d8cd98f00b204e9800998ecf8427e" },
@@ -299,13 +299,13 @@
                 new object[] { "SuperMassive", "cad0d67d052f61ad42b0010983663a45" },
             };
 
-            public static object[] Md5File =
+            public static readonly object[] Md5File =
             {
                 new object[] { "SuperMassive", "cad0d67d052f61ad42b0010983663a45", false },
                 new object[] { "SuperMassive", "ytDWfQUvYa1CsAEJg2Y6RQ==", true },
             };
 
-            public static object[] Sha1 =
+            public static readonly object[] Sha1 =
             {
                 new object[] { null, null },
                 new object[] { string.Empty, "da39a3ee5e6b4b0d3255bfef95601890afd80709" },
@@ -313,13 +313,13 @@
                 new object[] { "SuperMassive", "ba3fff6f7041385c8b75901f421e5c2db081ebea" },
             };
 
-            public static object[] Sha1File =
+            public static readonly object[] Sha1File =
             {
                 new object[] { "SuperMassive", "ba3fff6f7041385c8b75901f421e5c2db081ebea", false },
                 new object[] { "SuperMassive", "uj//b3BBOFyLdZAfQh5cLbCB6+o=", true },
             };
 
-            public static object[] Sha256 =
+            public static readonly object[] Sha256 =
             {
                 new object[] { null, null },
                 new object[] { string.Empty, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" },
@@ -327,14 +327,14 @@
                 new object[] { "SuperMassive", "9296c1a118328aad1201f1dcfead4d5aeb84580fae41157afacc4367f3e8b3d9" },
             };
 
-            public static object[] Sha256File =
+            public static readonly object[] Sha256File =
             {
                 new object[]
                     { "SuperMassive", "9296c1a118328aad1201f1dcfead4d5aeb84580fae41157afacc4367f3e8b3d9", false },
                 new object[] { "SuperMassive", "kpbBoRgyiq0SAfHc/q1NWuuEWA+uQRV6+sxDZ/Pos9k=", true },
             };
 
-            public static object[] Crc32 =
+            public static readonly object[] Crc32 =
             {
                 new object[] { null, null },
                 new object[] { string.Empty, "00000000" },
@@ -342,13 +342,13 @@
                 new object[] { "SuperMassive", "93ba819f" },
             };
 
-            public static object[] Crc32File =
+            public static readonly object[] Crc32File =
             {
                 new object[] { "SuperMassive", "93ba819f", false },
                 new object[] { "SuperMassive", "k7qBnw==", true },
             };
 
-            public static object[] Crc16 =
+            public static readonly object[] Crc16 =
             {
                 new object[] { null, null },
                 new object[] { string.Empty, "0000" },
@@ -356,7 +356,7 @@
                 new object[] { "SuperMassive", "184b" },
             };
 
-            public static object[] ByteToHex =
+            public static readonly object[] ByteToHex =
             {
                 new object[] { null, null },
                 new object[] { Encoding.UTF8.GetBytes(string.Empty), string.Empty },
@@ -364,7 +364,7 @@
                 new object[] { Encoding.UTF8.GetBytes("SuperMassive"), "53757065724d617373697665" },
             };
 
-            public static object[] Base64 =
+            public static readonly object[] Base64 =
             {
                 new object[] { null, null },
                 new object[] { string.Empty, string.Empty },


### PR DESCRIPTION
# Summary

Rework the CryptographyHelper class public API

# Changes description

* Introduce standardized naming using depreciation warnings
* Add hashing extension methods to string type

**BREAKING CHANGES**

Every hashing function now potentially return a null string.

This is the behavior found in v1.x, changed during the .NET Core
Nullable Reference Type migration.
This commit restores this behavior to its original state.